### PR TITLE
Clean up PR 413.

### DIFF
--- a/src/DotNet.Testcontainers/Builders/IImageFromDockerfileBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/IImageFromDockerfileBuilder.cs
@@ -2,7 +2,7 @@ namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Threading.Tasks;
-  using Configurations;
+  using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
 
@@ -52,21 +52,22 @@ namespace DotNet.Testcontainers.Builders
     IImageFromDockerfileBuilder WithDeleteIfExists(bool deleteIfExists);
 
     /// <summary>
-    /// Add a label to the resulting image.
+    /// Adds user-defined metadata to the Docker volume.
     /// </summary>
-    /// <param name="labelName">Name of the label.</param>
-    /// <param name="value">Value of the label.</param>
+    /// <param name="name">Label name.</param>
+    /// <param name="value">Label value.</param>
     /// <returns>A configured instance of <see cref="IImageFromDockerfileBuilder" />.</returns>
     [PublicAPI]
-    IImageFromDockerfileBuilder WithLabel(string labelName, string value);
+    IImageFromDockerfileBuilder WithLabel(string name, string value);
 
     /// <summary>
-    /// Sets the resource reaper session id for this image.
-    /// The <see cref="ResourceReaper"/> will make sure to delete the image after the tests have finished if it was not deleted explicitly.
+    /// Sets the resource reaper session id.
     /// </summary>
-    /// <param name="resourceReaperSessionId">The session id of the <see cref="ResourceReaper"/> instance.</param>
+    /// <param name="resourceReaperSessionId">The session id of the <see cref="ResourceReaper" /> instance.</param>
+    /// <returns>A configured instance of <see cref="IImageFromDockerfileBuilder" />.</returns>
+    /// <remarks>The <see cref="ResourceReaper" /> will delete the resource after the tests has been finished.</remarks>
     [PublicAPI]
-    IImageFromDockerfileBuilder WithResourceReaperSessionId(Guid? resourceReaperSessionId);
+    IImageFromDockerfileBuilder WithResourceReaperSessionId(Guid resourceReaperSessionId);
 
     /// <summary>
     /// Builds the instance of <see cref="IImageFromDockerfileBuilder" /> with the given configuration.

--- a/src/DotNet.Testcontainers/Builders/ITestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/ITestcontainersBuilder.cs
@@ -249,25 +249,25 @@ namespace DotNet.Testcontainers.Builders
     ITestcontainersBuilder<TDockerContainer> WithNetwork(IDockerNetwork dockerNetwork);
 
     /// <summary>
-    /// If true, Testcontainer will remove the Testcontainer on finalize. Otherwise, Testcontainer will keep the Testcontainer.
+    /// If true, the <see cref="ResourceReaper" /> will remove the stopped Testcontainer automatically. Otherwise, the Testcontainer will be kept.
     /// </summary>
-    /// <param name="cleanUp">True, Testcontainer will remove the Testcontainer on finalize. Otherwise, Testcontainer will keep it.</param>
+    /// <param name="cleanUp">True, the <see cref="ResourceReaper" /> will remove the stopped Testcontainer automatically. Otherwise, the Testcontainer will be kept.</param>
     /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
     [PublicAPI]
     ITestcontainersBuilder<TDockerContainer> WithCleanUp(bool cleanUp);
 
     /// <summary>
-    /// If true, the Testcontainer is removed automatically by the Docker daemon when stopped.
+    /// If true, the Docker daemon will remove the stopped Testcontainer automatically. Otherwise, the Testcontainer will be kept.
     /// </summary>
-    /// <param name="autoRemove">True, TestcontainerTestcontainer is removed automatically by the Docker daemon when stopped.</param>
+    /// <param name="autoRemove">True, the Docker daemon will remove the stopped Testcontainer automatically. Otherwise, the Testcontainer will be kept.</param>
     /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
     [PublicAPI]
     ITestcontainersBuilder<TDockerContainer> WithAutoRemove(bool autoRemove);
 
     /// <summary>
-    /// If true, the Testcontainer is removed automatically by the Docker daemon when stopped.
+    /// If true, the Testcontainer will get extended privileges. Otherwise, the Testcontainer will be unprivileged.
     /// </summary>
-    /// <param name="autoRemove">True, TestcontainerTestcontainer is removed automatically by the Docker daemon when stopped.</param>
+    /// <param name="privileged">The Testcontainer will get extended privileges. Otherwise, the Testcontainer will be unprivileged.</param>
     /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
     [PublicAPI]
     ITestcontainersBuilder<TDockerContainer> WithPrivileged(bool privileged);
@@ -318,13 +318,13 @@ namespace DotNet.Testcontainers.Builders
     ITestcontainersBuilder<TDockerContainer> WithStartupCallback(Func<IRunningDockerContainer, CancellationToken, Task> startupCallback);
 
     /// <summary>
-    /// Sets the resource reaper session id for this container.
-    /// The <see cref="ResourceReaper"/> will make sure to delete the container after the tests have finished if it was not deleted explicitly.
+    /// Sets the resource reaper session id.
     /// </summary>
-    /// <param name="resourceReaperSessionId">The session id of the <see cref="ResourceReaper"/> instance.</param>
+    /// <param name="resourceReaperSessionId">The session id of the <see cref="ResourceReaper" /> instance.</param>
     /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    /// <remarks>The <see cref="ResourceReaper" /> will delete the resource after the tests has been finished.</remarks>
     [PublicAPI]
-    ITestcontainersBuilder<TDockerContainer> WithResourceReaperSessionId(Guid? resourceReaperSessionId);
+    ITestcontainersBuilder<TDockerContainer> WithResourceReaperSessionId(Guid resourceReaperSessionId);
 
     /// <summary>
     /// Builds the instance of <see cref="ITestcontainersContainer" /> with the given configuration.

--- a/src/DotNet.Testcontainers/Builders/ITestcontainersNetworkBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/ITestcontainersNetworkBuilder.cs
@@ -44,13 +44,13 @@
     ITestcontainersNetworkBuilder WithLabel(string name, string value);
 
     /// <summary>
-    /// Sets the resource reaper session id for this network.
-    /// The <see cref="ResourceReaper"/> will make sure to delete the network after the tests have finished if it was not deleted explicitly.
+    /// Sets the resource reaper session id.
     /// </summary>
-    /// <param name="resourceReaperSessionId">The session id of the <see cref="ResourceReaper"/> instance.</param>
-    /// <returns>A configured instance of <see cref="ITestcontainersNetworkBuilder" />.</returns>
+    /// <param name="resourceReaperSessionId">The session id of the <see cref="ResourceReaper" /> instance.</param>
+    /// <returns>A configured instance of <see cref="IImageFromDockerfileBuilder" />.</returns>
+    /// <remarks>The <see cref="ResourceReaper" /> will delete the resource after the tests has been finished.</remarks>
     [PublicAPI]
-    ITestcontainersNetworkBuilder WithResourceReaperSessionId(Guid? resourceReaperSessionId);
+    ITestcontainersNetworkBuilder WithResourceReaperSessionId(Guid resourceReaperSessionId);
 
     /// <summary>
     /// Builds the instance of <see cref="IDockerNetwork" /> with the given configuration.

--- a/src/DotNet.Testcontainers/Builders/ITestcontainersVolumeBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/ITestcontainersVolumeBuilder.cs
@@ -36,12 +36,13 @@ namespace DotNet.Testcontainers.Builders
     ITestcontainersVolumeBuilder WithLabel(string name, string value);
 
     /// <summary>
-    /// Sets the resource reaper session id for this volume.
-    /// The <see cref="ResourceReaper"/> will make sure to delete the volume after the tests have finished if it was not deleted explicitly.
+    /// Sets the resource reaper session id.
     /// </summary>
-    /// <param name="resourceReaperSessionId">The session id of the <see cref="ResourceReaper"/> instance.</param>
-    /// <returns>A configured instance of <see cref="ITestcontainersVolumeBuilder" />.</returns>
-    ITestcontainersVolumeBuilder WithResourceReaperSessionId(Guid? resourceReaperSessionId);
+    /// <param name="resourceReaperSessionId">The session id of the <see cref="ResourceReaper" /> instance.</param>
+    /// <returns>A configured instance of <see cref="IImageFromDockerfileBuilder" />.</returns>
+    /// <remarks>The <see cref="ResourceReaper" /> will delete the resource after the tests has been finished.</remarks>
+    [PublicAPI]
+    ITestcontainersVolumeBuilder WithResourceReaperSessionId(Guid resourceReaperSessionId);
 
     /// <summary>
     /// Builds the instance of <see cref="IDockerVolume" /> with the given configuration.

--- a/src/DotNet.Testcontainers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/TestcontainersBuilder.cs
@@ -8,8 +8,6 @@ namespace DotNet.Testcontainers.Builders
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Configurations;
-  using DotNet.Testcontainers.Configurations.Containers;
-  using DotNet.Testcontainers.Configurations.Images;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Network;
@@ -57,7 +55,9 @@ namespace DotNet.Testcontainers.Builders
           labels: DefaultLabels.Instance,
           outputConsumer: Consume.DoNotConsumeStdoutAndStderr(),
           waitStrategies: Wait.ForUnixContainer().Build(),
-          startupCallback: (testcontainers, ct) => Task.CompletedTask),
+          startupCallback: (testcontainers, ct) => Task.CompletedTask,
+          autoRemove: false,
+          privileged: false),
         _ => { })
     {
     }
@@ -237,17 +237,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public ITestcontainersBuilder<TDockerContainer> WithCleanUp(bool cleanUp)
     {
-      if (cleanUp)
-      {
-        if (string.IsNullOrWhiteSpace(this.configuration.Labels[ResourceReaper.ResourceReaperSessionLabel]))
-        {
-          return this.WithResourceReaperSessionId(ResourceReaper.DefaultSessionId);
-        }
-
-        return this;
-      }
-
-      return this.WithResourceReaperSessionId(null);
+      return this.WithResourceReaperSessionId(cleanUp ? ResourceReaper.DefaultSessionId : Guid.Empty);
     }
 
     /// <inheritdoc />
@@ -293,9 +283,9 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public ITestcontainersBuilder<TDockerContainer> WithResourceReaperSessionId(Guid? resourceReaperSessionId)
+    public ITestcontainersBuilder<TDockerContainer> WithResourceReaperSessionId(Guid resourceReaperSessionId)
     {
-      return this.WithLabel(ResourceReaper.ResourceReaperSessionLabel, resourceReaperSessionId?.ToString("D"));
+      return this.WithLabel(ResourceReaper.ResourceReaperSessionLabel, resourceReaperSessionId.ToString("D"));
     }
 
     /// <inheritdoc />

--- a/src/DotNet.Testcontainers/Builders/TestcontainersBuilderResourceReaperExtension.cs
+++ b/src/DotNet.Testcontainers/Builders/TestcontainersBuilderResourceReaperExtension.cs
@@ -1,10 +1,13 @@
 namespace DotNet.Testcontainers.Builders
 {
-  using DotNet.Testcontainers.Containers.Modules.Misc;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
+  using JetBrains.Annotations;
 
   /// <summary>
   /// This class applies the extended Testcontainer configurations for the resource reaper.
   /// </summary>
+  [PublicAPI]
   public static class TestcontainersBuilderResourceReaperExtension
   {
     public static ITestcontainersBuilder<T> WithResourceReaper<T>(this ITestcontainersBuilder<T> builder, ResourceReaperContainerConfiguration configuration)
@@ -18,7 +21,7 @@ namespace DotNet.Testcontainers.Builders
         .WithPortBinding(configuration.Port, configuration.DefaultPort)
         .WithExposedPort(configuration.DefaultPort)
         .WithWaitStrategy(configuration.WaitStrategy)
-        .WithMount(configuration.HostDockerSocketPath, "/var/run/docker.sock");
+        .WithBindMount(configuration.HostDockerSocketPath, "/var/run/docker.sock", AccessMode.ReadOnly);
     }
   }
 }

--- a/src/DotNet.Testcontainers/Builders/TestcontainersNetworkBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/TestcontainersNetworkBuilder.cs
@@ -20,8 +20,8 @@
       : this(
         Apply(
           endpoint: TestcontainersSettings.OS.DockerApiEndpoint,
-          labels: DefaultLabels.Instance,
-          driver: NetworkDriver.Bridge))
+          driver: NetworkDriver.Bridge,
+          labels: DefaultLabels.Instance))
     {
     }
 
@@ -60,9 +60,9 @@
     }
 
     /// <inheritdoc />
-    public ITestcontainersNetworkBuilder WithResourceReaperSessionId(Guid? resourceReaperSessionId)
+    public ITestcontainersNetworkBuilder WithResourceReaperSessionId(Guid resourceReaperSessionId)
     {
-      return this.WithLabel(ResourceReaper.ResourceReaperSessionLabel, resourceReaperSessionId?.ToString("D"));
+      return this.WithLabel(ResourceReaper.ResourceReaperSessionLabel, resourceReaperSessionId.ToString("D"));
     }
 
     /// <inheritdoc />

--- a/src/DotNet.Testcontainers/Builders/TestcontainersVolumeBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/TestcontainersVolumeBuilder.cs
@@ -53,9 +53,9 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public ITestcontainersVolumeBuilder WithResourceReaperSessionId(Guid? resourceReaperSessionId)
+    public ITestcontainersVolumeBuilder WithResourceReaperSessionId(Guid resourceReaperSessionId)
     {
-      return this.WithLabel(ResourceReaper.ResourceReaperSessionLabel, resourceReaperSessionId?.ToString("D"));
+      return this.WithLabel(ResourceReaper.ResourceReaperSessionLabel, resourceReaperSessionId.ToString("D"));
     }
 
     /// <inheritdoc />

--- a/src/DotNet.Testcontainers/Clients/DefaultLabels.cs
+++ b/src/DotNet.Testcontainers/Clients/DefaultLabels.cs
@@ -2,7 +2,7 @@ namespace DotNet.Testcontainers.Clients
 {
   using System.Collections.Generic;
   using System.Collections.ObjectModel;
-  using Configurations;
+  using DotNet.Testcontainers.Configurations;
 
   internal sealed class DefaultLabels : ReadOnlyDictionary<string, string>
   {
@@ -10,7 +10,7 @@ namespace DotNet.Testcontainers.Clients
       : base(new Dictionary<string, string>
       {
         { TestcontainersClient.TestcontainersLabel, bool.TrueString },
-        { ResourceReaper.ResourceReaperSessionLabel, ResourceReaper.DefaultSessionId.ToString("D") }
+        { ResourceReaper.ResourceReaperSessionLabel, ResourceReaper.DefaultSessionId.ToString("D") },
       })
     {
     }

--- a/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
@@ -6,7 +6,6 @@ namespace DotNet.Testcontainers.Clients
   using System.Linq;
   using System.Threading;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
@@ -145,8 +144,8 @@ namespace DotNet.Testcontainers.Clients
 
       var hostConfig = new HostConfig
       {
-        AutoRemove = configuration.AutoRemove ?? false,
-        Privileged = configuration.Privileged ?? false,
+        AutoRemove = configuration.AutoRemove.HasValue && configuration.AutoRemove.Value,
+        Privileged = configuration.Privileged.HasValue && configuration.Privileged.Value,
         PortBindings = converter.PortBindings,
         Mounts = converter.Mounts,
       };

--- a/src/DotNet.Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerImageOperations.cs
@@ -7,7 +7,7 @@ namespace DotNet.Testcontainers.Clients
   using System.Threading;
   using System.Threading.Tasks;
   using Docker.DotNet.Models;
-  using DotNet.Testcontainers.Configurations.Images;
+  using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Images;
   using Microsoft.Extensions.Logging;
 
@@ -105,7 +105,7 @@ namespace DotNet.Testcontainers.Clients
       {
         Dockerfile = configuration.Dockerfile,
         Tags = new[] { image.FullName },
-        Labels = configuration.Labels.ToDictionary(kv => kv.Key, kv => kv.Value),
+        Labels = configuration.Labels.ToDictionary(item => item.Key, item => item.Value),
       };
 
       using (var dockerFileStream = new FileStream(dockerFileArchive.Tar(), FileMode.Open))

--- a/src/DotNet.Testcontainers/Clients/DockerVolumeOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerVolumeOperations.cs
@@ -25,12 +25,6 @@ namespace DotNet.Testcontainers.Clients
         .ConfigureAwait(false)).Volumes.ToArray();
     }
 
-    public Task<IEnumerable<VolumeResponse>> GetOrphanedObjects(CancellationToken ct = default)
-    {
-      IEnumerable<VolumeResponse> volumes = Array.Empty<VolumeResponse>();
-      return Task.FromResult(volumes);
-    }
-
     public Task<VolumeResponse> ByIdAsync(string id, CancellationToken ct = default)
     {
       throw new NotImplementedException();

--- a/src/DotNet.Testcontainers/Clients/IDockerContainerOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/IDockerContainerOperations.cs
@@ -4,7 +4,6 @@ namespace DotNet.Testcontainers.Clients
   using System.IO;
   using System.Threading;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;

--- a/src/DotNet.Testcontainers/Clients/IDockerImageOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/IDockerImageOperations.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Clients
 {
   using System.Threading;
   using System.Threading.Tasks;
-  using Configurations.Images;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Images;

--- a/src/DotNet.Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/DotNet.Testcontainers/Clients/ITestcontainersClient.cs
@@ -3,8 +3,6 @@ namespace DotNet.Testcontainers.Clients
   using System.Collections.Generic;
   using System.Threading;
   using System.Threading.Tasks;
-  using Configurations.Containers;
-  using Configurations.Images;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;

--- a/src/DotNet.Testcontainers/Clients/TestcontainersConfigurationConverter.cs
+++ b/src/DotNet.Testcontainers/Clients/TestcontainersConfigurationConverter.cs
@@ -3,7 +3,6 @@ namespace DotNet.Testcontainers.Clients
   using System;
   using System.Collections.Generic;
   using System.Linq;
-  using Configurations.Containers;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Network;

--- a/src/DotNet.Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
+++ b/src/DotNet.Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
@@ -1,10 +1,9 @@
-namespace DotNet.Testcontainers.Configurations.Containers
+namespace DotNet.Testcontainers.Configurations
 {
   using System;
   using System.Collections.Generic;
   using System.Threading;
   using System.Threading.Tasks;
-  using DotNet.Testcontainers.Configurations.Images;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Network;
@@ -16,13 +15,15 @@ namespace DotNet.Testcontainers.Configurations.Containers
   public interface ITestcontainersConfiguration
   {
     /// <summary>
-    /// If true, the Testcontainer is removed automatically by the Docker daemon when stopped.
+    /// Gets a value indicating whether the Testcontainer is removed by the Docker daemon or not.
     /// </summary>
+    [CanBeNull]
     bool? AutoRemove { get; }
 
     /// <summary>
-    /// If true, the Testcontainer will be started in privileged mode.
+    /// Gets a value indicating whether the Testcontainer has extended privileges or not.
     /// </summary>
+    [CanBeNull]
     bool? Privileged { get; }
 
     /// <summary>

--- a/src/DotNet.Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
+++ b/src/DotNet.Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
@@ -1,4 +1,4 @@
-namespace DotNet.Testcontainers.Configurations.Containers
+namespace DotNet.Testcontainers.Configurations
 {
   using System;
   using System.Collections.Generic;
@@ -7,7 +7,6 @@ namespace DotNet.Testcontainers.Configurations.Containers
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Network;
-  using Images;
 
   /// <inheritdoc cref="ITestcontainersConfiguration" />
   public readonly struct TestcontainersConfiguration : ITestcontainersConfiguration
@@ -34,7 +33,8 @@ namespace DotNet.Testcontainers.Configurations.Containers
     /// <param name="outputConsumer">The output consumer.</param>
     /// <param name="waitStrategies">The wait strategies.</param>
     /// <param name="startupCallback">The startup callback.</param>
-    /// <param name="cleanUp">A value indicating whether the Testcontainer is removed on finalize or not.</param>
+    /// <param name="autoRemove">A value indicating whether the Testcontainer is removed by the Docker daemon or not.</param>
+    /// <param name="privileged">A value indicating whether the Testcontainer has extended  privilegesor not.</param>
     public TestcontainersConfiguration(
       Uri endpoint,
       IDockerRegistryAuthenticationConfiguration dockerRegistryAuthenticationConfigurations,

--- a/src/DotNet.Testcontainers/Configurations/Images/DockerRegistryAuthenticationConfiguration.cs
+++ b/src/DotNet.Testcontainers/Configurations/Images/DockerRegistryAuthenticationConfiguration.cs
@@ -1,4 +1,4 @@
-namespace DotNet.Testcontainers.Configurations.Images
+namespace DotNet.Testcontainers.Configurations
 {
   using System;
 

--- a/src/DotNet.Testcontainers/Configurations/Images/IDockerRegistryAuthenticationConfiguration.cs
+++ b/src/DotNet.Testcontainers/Configurations/Images/IDockerRegistryAuthenticationConfiguration.cs
@@ -1,4 +1,4 @@
-namespace DotNet.Testcontainers.Configurations.Images
+namespace DotNet.Testcontainers.Configurations
 {
   using System;
   using JetBrains.Annotations;

--- a/src/DotNet.Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
+++ b/src/DotNet.Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
@@ -1,4 +1,4 @@
-namespace DotNet.Testcontainers.Configurations.Images
+namespace DotNet.Testcontainers.Configurations
 {
   using System.Collections.Generic;
   using DotNet.Testcontainers.Images;
@@ -21,12 +21,6 @@ namespace DotNet.Testcontainers.Configurations.Images
     string Dockerfile { get; }
 
     /// <summary>
-    /// Gets the Labels.
-    /// </summary>
-    [NotNull]
-    IReadOnlyDictionary<string, string> Labels { get; }
-
-    /// <summary>
     /// Gets the Dockerfile directory.
     /// </summary>
     [NotNull]
@@ -37,5 +31,11 @@ namespace DotNet.Testcontainers.Configurations.Images
     /// </summary>
     [NotNull]
     IDockerImage Image { get; }
+
+    /// <summary>
+    /// Gets a list of labels.
+    /// </summary>
+    [NotNull]
+    IReadOnlyDictionary<string, string> Labels { get; }
   }
 }

--- a/src/DotNet.Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/DotNet.Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -1,8 +1,6 @@
-namespace DotNet.Testcontainers.Configurations.Images
+namespace DotNet.Testcontainers.Configurations
 {
   using System.Collections.Generic;
-  using System.IO;
-  using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Images;
 
   /// <inheritdoc cref="IImageFromDockerfileConfiguration" />
@@ -11,30 +9,23 @@ namespace DotNet.Testcontainers.Configurations.Images
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
     /// </summary>
-    public ImageFromDockerfileConfiguration()
-      : this(CreateDockerImage())
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
-    /// </summary>
     /// <param name="image">The Docker image.</param>
     /// <param name="dockerfile">The Dockerfile.</param>
     /// <param name="dockerfileDirectory">The Dockerfile directory.</param>
     /// <param name="deleteIfExists">A value indicating whether an existing image is removed or not.</param>
+    /// <param name="labels">A list of labels.</param>
     public ImageFromDockerfileConfiguration(
       IDockerImage image,
-      string dockerfile = "Dockerfile",
-      string dockerfileDirectory = ".",
-      bool deleteIfExists = true,
-      IReadOnlyDictionary<string, string> labels = null)
+      string dockerfile,
+      string dockerfileDirectory,
+      bool deleteIfExists,
+      IReadOnlyDictionary<string, string> labels)
     {
-      this.DeleteIfExists = deleteIfExists;
+      this.Image = image;
       this.Dockerfile = dockerfile;
       this.DockerfileDirectory = dockerfileDirectory;
-      this.Image = image;
-      this.Labels = labels ?? DefaultLabels.Instance;
+      this.DeleteIfExists = deleteIfExists;
+      this.Labels = labels;
     }
 
     /// <inheritdoc />
@@ -51,10 +42,5 @@ namespace DotNet.Testcontainers.Configurations.Images
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> Labels { get; }
-
-    private static IDockerImage CreateDockerImage()
-    {
-      return new DockerImage("Testcontainers", Path.GetRandomFileName().Substring(0, 8), string.Empty);
-    }
   }
 }

--- a/src/DotNet.Testcontainers/Configurations/ResourceReaper.cs
+++ b/src/DotNet.Testcontainers/Configurations/ResourceReaper.cs
@@ -8,7 +8,7 @@ namespace DotNet.Testcontainers.Configurations
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Clients;
-  using DotNet.Testcontainers.Containers.Modules.Misc;
+  using DotNet.Testcontainers.Containers;
   using Microsoft.Extensions.Logging;
 
   public class ResourceReaper : IAsyncDisposable

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/CouchDbTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/CouchDbTestcontainer.cs
@@ -1,6 +1,5 @@
 namespace DotNet.Testcontainers.Containers
 {
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/CouchbaseTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/CouchbaseTestcontainer.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Containers
 {
   using System.Text;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/MongoDbTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/MongoDbTestcontainer.cs
@@ -1,6 +1,5 @@
 ﻿namespace DotNet.Testcontainers.Containers
 {
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/MsSqlTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/MsSqlTestcontainer.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Containers
 {
   using System.Text;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/MySqlTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/MySqlTestcontainer.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Containers
 {
   using System.Text;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/OracleTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/OracleTestcontainer.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Containers
 {
   using System.Text;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/PostgreSqlTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/PostgreSqlTestcontainer.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Containers
 {
   using System.Text;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/RedisTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/RedisTestcontainer.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Containers
 {
   using System.Text;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/HostedServiceContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/HostedServiceContainer.cs
@@ -1,6 +1,6 @@
-namespace DotNet.Testcontainers.Containers.Modules
+namespace DotNet.Testcontainers.Containers
 {
-  using DotNet.Testcontainers.Configurations.Containers;
+  using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
 

--- a/src/DotNet.Testcontainers/Containers/Modules/IDatabaseScript.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/IDatabaseScript.cs
@@ -1,4 +1,4 @@
-namespace DotNet.Testcontainers.Containers.Modules
+namespace DotNet.Testcontainers.Containers
 {
   using System.Threading.Tasks;
   using JetBrains.Annotations;

--- a/src/DotNet.Testcontainers/Containers/Modules/MessageBrokers/KafkaTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/MessageBrokers/KafkaTestcontainer.cs
@@ -1,6 +1,5 @@
 namespace DotNet.Testcontainers.Containers
 {
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/MessageBrokers/RabbitMqTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/MessageBrokers/RabbitMqTestcontainer.cs
@@ -1,6 +1,5 @@
 namespace DotNet.Testcontainers.Containers
 {
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;

--- a/src/DotNet.Testcontainers/Containers/Modules/ResourceReaperContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/ResourceReaperContainer.cs
@@ -1,6 +1,6 @@
-namespace DotNet.Testcontainers.Containers.Modules.Misc
+namespace DotNet.Testcontainers.Containers
 {
-  using DotNet.Testcontainers.Configurations.Containers;
+  using DotNet.Testcontainers.Configurations;
   using Microsoft.Extensions.Logging;
 
   public class ResourceReaperContainer : TestcontainersContainer

--- a/src/DotNet.Testcontainers/Containers/Modules/ResourceReaperContainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/ResourceReaperContainerConfiguration.cs
@@ -1,4 +1,4 @@
-namespace DotNet.Testcontainers.Containers.Modules.Misc
+namespace DotNet.Testcontainers.Containers
 {
   using System;
   using DotNet.Testcontainers.Builders;

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainerDatabase.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainerDatabase.cs
@@ -4,8 +4,6 @@ namespace DotNet.Testcontainers.Containers
   using System.Text;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
-  using DotNet.Testcontainers.Configurations.Containers;
-  using DotNet.Testcontainers.Containers.Modules;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
 

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainerMessageBroker.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainerMessageBroker.cs
@@ -1,9 +1,7 @@
 namespace DotNet.Testcontainers.Containers
 {
-  using Configurations.Containers;
   using DotNet.Testcontainers.Configurations;
   using Microsoft.Extensions.Logging;
-  using Modules;
 
   /// <summary>
   /// This class represents an extended configured and created Testcontainer for message brokers.

--- a/src/DotNet.Testcontainers/Containers/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/TestcontainersContainer.cs
@@ -5,7 +5,6 @@ namespace DotNet.Testcontainers.Containers
   using System.Linq;
   using System.Threading;
   using System.Threading.Tasks;
-  using Configurations.Containers;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Configurations;
@@ -217,7 +216,8 @@ namespace DotNet.Testcontainers.Containers
         return;
       }
 
-      await this.StopAsync().ConfigureAwait(false);
+      await this.StopAsync()
+        .ConfigureAwait(false);
 
       this.semaphoreSlim.Dispose();
 

--- a/tests/DotNet.Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/MsSqlFixture.cs
+++ b/tests/DotNet.Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/MsSqlFixture.cs
@@ -28,7 +28,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public override async Task DisposeAsync()
     {
-      this.Connection?.Dispose();
+      this.Connection.Dispose();
 
       await this.Container.DisposeAsync()
         .ConfigureAwait(false);

--- a/tests/DotNet.Testcontainers.Tests/Unit/Clients/TestcontainersConfigurationConverterTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Clients/TestcontainersConfigurationConverterTest.cs
@@ -1,9 +1,9 @@
-namespace DotNet.Testcontainers.Tests.Unit.Clients
+namespace DotNet.Testcontainers.Tests.Unit
 {
   using System.Collections.Generic;
   using System.Linq;
   using DotNet.Testcontainers.Clients;
-  using DotNet.Testcontainers.Configurations.Containers;
+  using DotNet.Testcontainers.Configurations;
   using Moq;
   using Xunit;
 

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/MsSqlTestcontainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/MsSqlTestcontainerTest.cs
@@ -17,7 +17,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       this.msSqlFixture = msSqlFixture;
     }
 
-    [IgnoreOnLinuxEngine]
+    [Fact]
     public async Task ConnectionEstablished()
     {
       // Given
@@ -31,21 +31,21 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.Equal(ConnectionState.Open, connection.State);
     }
 
-    [IgnoreOnLinuxEngine]
+    [Fact]
     public void CannotSetDatabase()
     {
       var mssql = new MsSqlTestcontainerConfiguration();
       Assert.Throws<NotImplementedException>(() => mssql.Database = string.Empty);
     }
 
-    [IgnoreOnLinuxEngine]
+    [Fact]
     public void CannotSetUsername()
     {
       var mssql = new MsSqlTestcontainerConfiguration();
       Assert.Throws<NotImplementedException>(() => mssql.Username = string.Empty);
     }
 
-    [IgnoreOnLinuxEngine]
+    [Fact]
     public async Task ExecScriptInRunningContainer()
     {
       // Given
@@ -67,7 +67,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.Contains("MyName", result.Stdout);
     }
 
-    [IgnoreOnLinuxEngine]
+    [Fact]
     public async Task ThrowErrorInRunningContainerWithInvalidScript()
     {
       // Given

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -17,7 +17,8 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
 
   public static class TestcontainersContainerTest
   {
-    private static readonly string TempDir = Environment.GetEnvironmentVariable("AGENT_TEMPDIRECTORY") ?? Directory.GetCurrentDirectory(); // We cannot use `Path.GetTempPath()` on macOS, see: https://github.com/common-workflow-language/cwltool/issues/328.
+    // We cannot use `Path.GetTempPath()` on macOS, see: https://github.com/common-workflow-language/cwltool/issues/328.
+    private static readonly string TempDir = Environment.GetEnvironmentVariable("AGENT_TEMPDIRECTORY") ?? Directory.GetCurrentDirectory();
 
     [Collection(nameof(Testcontainers))]
     public sealed class WithConfiguration
@@ -84,7 +85,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
       public async Task SpecifiedContainerName()
       {
         // Given
-        var name = Guid.NewGuid().ToString("N");
+        var name = Guid.NewGuid().ToString("D");
 
         // When
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()


### PR DESCRIPTION
Thanks for your PR. Before I'll start with the `ResourceReaper` review, I cleaned up some parts of your changes.

- Update `ImageFromDockerfileBuilder` to the builder pattern in this project (I'll move some parts in a base implementation in the future)
- Upate XML documentation comments 
- Fix namespaces
- Remove unnessary changes (`MsSqlTestcontainerTest`, `MsSqlFixture`, etc.)
- I removed the logic in `WithCleanUp`. I think we should change some parts here. `WithCleanUp` feels unnecessary with ryuk. `WithCleanUp` and `WithResourceReaperSessionId` are very similar.